### PR TITLE
Ignore whitespace in sharedStrings.xml

### DIFF
--- a/OpenXLSX/sources/XLDocument.cpp
+++ b/OpenXLSX/sources/XLDocument.cpp
@@ -480,6 +480,7 @@ void XLDocument::open(const std::string& fileName)
     }
 
     for (const auto& node : getXmlData("xl/sharedStrings.xml")->getXmlDocument()->document_element().children()){
+        if(node.type() != pugi::node_element) continue; 
         if (std::string(node.first_child().name()) == "r") {
             std::string result;
             for (const auto& elem : node.children())


### PR DESCRIPTION
I have some XLSX files in which `sharedStrings.xml` is formatted like this:

```
<?xml version="1.0"?><sst xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" count="1" uniqueCount="1">
  <si>
    <t/>
  </si>
</sst>
```

The whitespace in the XML will make OpenXLSX misbehave. In fact, this XML will cause OpenXLSX to add three items to  `m_sharedStringCache` even though there is only string in the XML. Adding three items will totally screw up the string index mappings so this is quite a critical issue which should be fixed.